### PR TITLE
add more support for HK

### DIFF
--- a/Clash-Template-Config.yml
+++ b/Clash-Template-Config.yml
@@ -139,7 +139,7 @@ BASE-DATA:
       proxy-file-path-local: &proxy-file-path-local myprovider/proxies/provider-local.yml
     proxy-providers-filter:
       proxy-filter-WARP: &proxy-filter-WARP 'WARP+'
-      proxy-filter-HK: &proxy-filter-HK '港|HK|HongKong'
+      proxy-filter-HK: &proxy-filter-HK '港|HK|HongKong|Hong Kong'
       proxy-filter-TW: &proxy-filter-TW '台湾|TW|Taiwan'
       proxy-filter-SG: &proxy-filter-SG '新加坡|SG|Singapore'
       proxy-filter-JP: &proxy-filter-JP '日本|JP|Japan'


### PR DESCRIPTION
不知道阁下是否能接受这个情况，有些机场的Hongkong是隔开的，例如这种：

![image](https://github.com/user-attachments/assets/ce0ba40e-2d53-44d1-90f9-275ae1d2c6e3)

我已经测试过这个配置了，修改完后可以匹配到

![image](https://github.com/user-attachments/assets/5d67c067-63eb-4348-b697-3e70f8cd3d21)

