### PR TITLE
add perplexity rule-set and proxy-group

### DIFF
--- a/Clash-Template-Config.yml
+++ b/Clash-Template-Config.yml
@@ -123,7 +123,18 @@ BASE-DATA:
       - 🇫🇷 AIRPORT-FR
       - 🇦🇺 AIRPORT-AU
       - AIRPORT
-  
+    proxies-all-for-perplexity: &proxies-all-for-perplexity
+      - 🇺🇸 AIRPORT-US
+      - 🇬🇧 AIRPORT-EN
+      - 🇰🇷 AIRPORT-Korea
+      - 🇯🇵 AIRPORT-JP
+      - 🇸🇬 AIRPORT-SG
+      - 🇮🇪 AIRPORT-Ireland
+      - 🇨🇦 AIRPORT-Canada
+      - 🇫🇷 AIRPORT-FR
+      - 🇦🇺 AIRPORT-AU
+      - AIRPORT
+
   proxy-providers-config:
     proxy-providers-use: &proxy-providers-use 
       - airport
@@ -224,6 +235,9 @@ BASE-DATA:
       Gemini:
         rule-file-path-Gemini: &rule-file-path-Gemini myprovider/ruleset/Gemini.yaml
         rule-provider-url-Gemini: &rule-provider-url-Gemini https://cdn.jsdelivr.net/gh/zuluion/Clash-Template-Config@master/Filter/Gemini.yaml
+      Perplexity:
+        rule-file-path-Perplexity: &rule-file-path-Perplexity myprovider/ruleset/Perplexity.yaml
+        rule-provider-url-Perplexity: &rule-provider-url-Perplexity https://cdn.jsdelivr.net/gh/zuluion/Clash-Template-Config@master/Filter/Perplexity.yaml
       Spotify:
         rule-file-path-Spotify: &rule-file-path-Spotify myprovider/ruleset/Spotify.yaml
         rule-provider-url-Spotify: &rule-provider-url-Spotify https://cdn.jsdelivr.net/gh/zuluion/Clash-Template-Config@master/Filter/Spotify.yaml
@@ -338,6 +352,7 @@ BASE-DATA:
     icon-Pikpak: &icon-Pikpak https://cdn.jsdelivr.net/gh/zuluion/Qure/IconSet/Color/Pikpak.png
     icon-Claude: &icon-Claude https://cdn.jsdelivr.net/gh/zuluion/Qure/IconSet/Color/Claude.png
     icon-Gemini: &icon-Gemini https://cdn.jsdelivr.net/gh/zuluion/Qure/IconSet/Color/AI.png
+    icon-Perplexity: &icon-Perplexity https://cdn.jsdelivr.net/gh/zuluion/Qure/IconSet/Color/AI.png
     icon-Ubisoft: &icon-Ubisoft https://cdn.jsdelivr.net/gh/zuluion/Qure/IconSet/Color/Ubisoft.png
     icon-Auto: &icon-Auto https://cdn.jsdelivr.net/gh/zuluion/Qure/IconSet/Color/Auto.png
 # ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -625,6 +640,11 @@ proxy-groups:
     type: select
     proxies:
       *proxies-all-for-gemini
+  - name: Perplexity
+    icon: *icon-Perplexity
+    type: select
+    proxies:
+      *proxies-all-for-perplexity
   -
     name: Youtube
     icon: *icon-YouTube
@@ -928,6 +948,7 @@ rules:
   - RULE-SET,OpenAI,OpenAI
   - RULE-SET,Claude,Claude
   - RULE-SET,Gemini,Gemini
+  - RULE-SET,Perplexity,Perplexity
   - RULE-SET,DownLoadClient,DIRECT
   - RULE-SET,ProxyClient,DIRECT
   - RULE-SET,AdBlock,REJECT
@@ -1063,6 +1084,12 @@ rule-providers:
     behavior: classical
     path: *rule-file-path-Copilot
     url: *rule-provider-url-Copilot
+    interval: *rule-interval
+  Perplexity:
+    type: http
+    behavior: classical
+    path: *rule-file-path-Perplexity
+    url: *rule-provider-url-Perplexity
     interval: *rule-interval
   Netflix: 
     type: http

--- a/Filter/Perplexity.yaml
+++ b/Filter/Perplexity.yaml
@@ -1,0 +1,5 @@
+# NAME: Perplexity
+payload:
+  - DOMAIN,pplx-res.cloudinary.com
+  - DOMAIN-SUFFIX,perplexity.ai
+  - DOMAIN-SUFFIX,pplx.ai


### PR DESCRIPTION
## 大致内容

不知道阁下是否使用 perplexity 如果您这边需要的话可以接收这个 pr 不接受也没关系，我看了一下 perplexity 还是有用户需求的，因为 perplexity 查 VPN 还是有要求的

- [perplexity blocks VPN,导致使用频率严重降低](https://linux.do/t/topic/78881)
- [请求添加perplexity的分流规则](https://github.com/blackmatrix7/ios_rule_script/issues/1200)

## 一些写过的yaml和抓包测试

我看之前 GitHub 有人写过

> https://github.com/kingwang1976/PPLX/blob/main/Perplexity.list

具体内容为：
```
#Perplexity
DOMAIN-SUFFIX,www.perplexity.ai,Perlexity
DOMAIN-SUFFIX,pplx.ai,Perlexity
```

然后我进行了测试，发现不仅有：`www.perplexity.ai`，还有`suggest.perplexity.ai`，同时还发现如果进入 perplexity 资源库还可能存在一个URL 为：pplx-res.cloudinary.com

所以 perplexity.yaml 最终的内容为：
```
# NAME: Perplexity
payload:
  - DOMAIN,pplx-res.cloudinary.com
  - DOMAIN-SUFFIX,perplexity.ai
  - DOMAIN-SUFFIX,pplx.ai
```

测试过程：
1. 测试之前的：
![iShot_2024-11-10_19 05 26](https://github.com/user-attachments/assets/c0282fe9-6756-44dd-a32e-e188d4754ff2)
![iShot_2024-11-10_19 07 15](https://github.com/user-attachments/assets/eb274d5a-f675-4c49-8b35-308a52f38a6f)

2. 使用了我自己的raw进行了测试`https://raw.githubusercontent.com/zhiyu1998/Clash-Template-Config/refs/heads/master/Filter/Perplexity.yaml`：
![iShot_2024-11-10_19 31 47](https://github.com/user-attachments/assets/9ec590ec-6a86-429a-863c-38948d7ecf1c)
![iShot_2024-11-10_19 28 36](https://github.com/user-attachments/assets/98240e33-f90f-42e3-b7c1-4d60ac013062)

> [!IMPORTANT]
> 暂时发现的几个分流点介绍：
> www.perplexity.ai 是主站
> pplx.ai 没遇到过但是之前有人写
> pplx-res.cloudinary.com 是在发现模块
> suggest.perplexity.ai 是在主页的建议

## ❌ 已知问题

图标在您fork的Qure仓库没找到，或许我可以帮你在iconfont找一找，暂时就先用着gemini的图标，在`355行`：
```
icon-Perplexity: &icon-Perplexity https://cdn.jsdelivr.net/gh/zuluion/Qure/IconSet/Color/AI.png
```